### PR TITLE
fix warning due to version-check

### DIFF
--- a/bind9/bind9_statchannel
+++ b/bind9/bind9_statchannel
@@ -52,7 +52,7 @@ MIT license
 
 use strict;
 use warnings;
-use v5.10;
+use 5.010;
 use LWP::UserAgent; #libwww-perl
 use XML::Simple; #libxml-simple-perl
 #use Net::INET6Glue::INET_is_INET6; #libnet-inet6glue-perl (requires Debian 6+)


### PR DESCRIPTION
some perl-versions print a warning "v-string in use/require non-portable". Fix that by using the portable version of that version check.