### PR TITLE
Faster XML default

### DIFF
--- a/bind9/bind9_statchannel
+++ b/bind9/bind9_statchannel
@@ -67,6 +67,9 @@ if (defined $ENV{'VIEW'}) {
 } elsif (defined $ENV{'VIEWS'}) {
 	@VIEWS = split(/,/,$ENV{'VIEWS'});
 }
+unless (defined($ENV{'XML_SIMPLE_PREFERRED_PARSER'})) {
+  $ENV{'XML_SIMPLE_PREFERRED_PARSER'} = 'XML::Parser';
+}
 
 #raise warnings in case of flood of ANY queries
 my $anywarn = $ENV{'ANYWARN'} || "10";

--- a/bind9/bind9_statchannel
+++ b/bind9/bind9_statchannel
@@ -14,6 +14,11 @@ The following environment variables are used by this plugin
  ANYWARN  - Warning level for type ANY queries
  ANYCRIT  - Critical level for type ANY queries
  VIEWS    - The names of the views to use. Defaults to autodiscovery. (comma separated values)
+ XML_SIMPLE_PREFERRED_PARSER
+          - tells XML::Simple which parser to use. If XML::SAX is installed, XML::Simple
+            will default to that, and it is EXTREMELY sluggish.
+            so we default to XML::Parser. You can override that default choice by setting
+            the environment variable (e.g. back to XML::SAX if XML::Parser isn't installed).
 
 =head1 USAGE
 


### PR DESCRIPTION
If XML::SAX is installed, XML::Simple will default to using that as a parser, but it is extremely slow. XML::Parser would be a much saner default and is A LOT faster. On my test machine this brings down the execution time of the plugin from 11 to 1.7 seconds.
This patch sets the preffered parser to XML::Parser if no other module is explicitly selected.