### PR TITLE
print fixed fields with value 0 if missing in XML

### DIFF
--- a/bind9/bind9_statchannel
+++ b/bind9/bind9_statchannel
@@ -248,8 +248,17 @@ sub format_output {
 	my $graphname = $_[0];
 	my $datatype = $_[1];
 	my %values = get_values($graphname, $datatype);
-	while (my ($field,$value) = each %values) {
-		print $field.".value ".$value."\n";
+	my @list = @{$graphs->{$graphname}{fields}} if defined $graphs->{$graphname}{fields};
+	if (!@list) {
+		while (my ($field,$value) = each %values) {
+			print $field.".value ".$value."\n";
+		}
+	} else {
+		foreach my $field (@list) {
+			my $v = 0;
+			if (defined($values{$field})) { $v = $values{$field}; }
+			print("$field.value $v\n");
+		}
 	}
 }
 


### PR DESCRIPTION
If we have a fixed fields-list, always print all of those fields, even if they are missing from the XML-output (in this case with value 0).

This is necessary because in 'config' mode we also give that fixed fields list, and if we don't do the same when printing the values, they will all show as "NaN" in munin. This mostly/only affects the cache db rrsets graph, but it is very irritating there.